### PR TITLE
fix: 회원 탈퇴 오류 해결 및 soft delete 방식으로 변경 #54

### DIFF
--- a/src/main/java/com/example/younet/domain/User.java
+++ b/src/main/java/com/example/younet/domain/User.java
@@ -6,6 +6,7 @@ import com.example.younet.domain.enums.LoginType;
 import com.example.younet.domain.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -18,6 +19,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Where(clause = "is_del = false")
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/younet/login/controller/UserAuthController.java
+++ b/src/main/java/com/example/younet/login/controller/UserAuthController.java
@@ -102,9 +102,9 @@ public class UserAuthController {
     }
 
     // 일반 회원탈퇴
-    @DeleteMapping("/user/withdrawl")
+    @PatchMapping("/user/withdrawl")
     public ApplicationResponse<String> userWithdrawl(HttpServletRequest request, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        generalAuthService.deleteUserWithdrawl(principalDetails);
+        generalAuthService.patchUserWithdrawl(principalDetails);
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "회원 탈퇴가 완료되었습니다.");
     }
 

--- a/src/main/java/com/example/younet/login/service/GeneralAuthService.java
+++ b/src/main/java/com/example/younet/login/service/GeneralAuthService.java
@@ -1,6 +1,5 @@
 package com.example.younet.login.service;
 
-import com.example.younet.domain.CommunityProfile;
 import com.example.younet.domain.User;
 import com.example.younet.domain.enums.AuthType;
 import com.example.younet.domain.enums.LoginType;
@@ -22,6 +21,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -163,8 +164,10 @@ public class GeneralAuthService {
 
     }
 
-    public void deleteUserWithdrawl(PrincipalDetails principalDetails) {
+    public void patchUserWithdrawl(PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
-        userRepository.delete(user);
+        user.setDel(true);
+        user.setInactiveDate(LocalDate.from(LocalDateTime.now()));
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
- 회원 탈퇴 hard delete -> soft delete 방식으로 변경
- 회원 탈퇴한 경우, isAuth 값 1로 세팅
- 회원 탈퇴한 경우, inactiveDate 값 세팅
- 회원 탈퇴한 경우 @where을 통해 hibernate에서 조회되지 않도록 하여, 해당 유저의 경우 사용할 수 없는 유저로 뜸