### PR TITLE
[fix] 댓글 / 대댓글 알람 데이터가 정상적으로 저장되지 않는 문제 수정

### DIFF
--- a/src/main/java/com/example/younet/comment/service/CommentService.java
+++ b/src/main/java/com/example/younet/comment/service/CommentService.java
@@ -49,7 +49,7 @@ public class CommentService {
 
         CommunityProfile communityProfile = communityProfileRepository.findById(requestDto.getCommunityProfileId())
                 .orElseThrow(() -> new IllegalArgumentException("커뮤니티 프로필을 찾을 수 없습니다."));
-        Post post = postRepository.findById(requestDto.getCommunityProfileId())
+        Post post = postRepository.findById(requestDto.getPostId())
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 달 게시글 ID를 찾을 수 없습니다."));
 
         Comment newComment = Comment.builder()

--- a/src/main/java/com/example/younet/reply/service/ReplyService.java
+++ b/src/main/java/com/example/younet/reply/service/ReplyService.java
@@ -67,7 +67,7 @@ public class ReplyService {
 
         CommunityProfile communityProfile = communityProfileRepository.findById(requestDto.getCommunityProfileId())
                 .orElseThrow(() -> new IllegalArgumentException("커뮤니티 프로필을 찾을 수 없습니다."));
-        Post post = postRepository.findById(requestDto.getCommunityProfileId())
+        Post post = postRepository.findById(requestDto.getPostId())
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 달 게시글 ID를 찾을 수 없습니다."));
         Comment comment = commentRepository.findById(requestDto.getCommentId())
                 .orElseThrow(() -> new IllegalArgumentException("답글을 달 댓글 ID를 찾을 수 없습니다."));


### PR DESCRIPTION
Post를 DB에서 조회할 때, DTO에서 받은 PostId로 조회해야 하는데, CommunityProfileId로 조회해서 생긴 문제 같습니다.